### PR TITLE
Use URN for module.xml XSD pathing

### DIFF
--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -33,7 +33,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="ShipperHQ_Common" setup_version="1.0.0" >
         <sequence>
             <module name="Magento_Config"/>


### PR DESCRIPTION
As mentioned here https://github.com/shipperhq/module-shipper/pull/3

URN should be used in place of relative paths.
